### PR TITLE
Feat/jwt

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 DATABASE_URL=postgresql://root:root@localhost:5432/mydb?schema=public
+SECRET=just_a_development_secret

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "@mui/material": "^5.10.3",
     "@prisma/client": "^4.2.1",
     "axios": "^0.27.2",
+    "jwt-decode": "^3.1.2",
+    "jwt-simple": "^0.5.6",
     "next": "12.2.5",
     "next-auth": "^4.10.3",
     "prisma": "^4.3.1",

--- a/src/context/authContext.tsx
+++ b/src/context/authContext.tsx
@@ -1,37 +1,28 @@
-import axios from "axios";
-import { useRouter } from "next/router";
+import jwt_decode from 'jwt-decode';
+import { useRouter } from 'next/router';
 import {createContext, useContext, useEffect, useState} from "react";
 
 const AuthContext = createContext(undefined);
 
 function AuthProvider({ children }) {
-  const [token, setToken] = useState('');
-  const [authenticated, setAuthenticated] = useState(false);
-  const [user, setUser] = useState([]);
+  const [user, setUser] = useState(undefined);
 
   const router = useRouter();
 
   useEffect(() => {
-    if (
-      !authenticated &&
-      router.pathname !== '/login' &&
-      router.pathname !== '/_error'
-    ) {
+    const token = localStorage.getItem('token');
+
+    if (token) {
+      //TODO: Check on api if token is valid
+      const user = jwt_decode(token);
+      setUser(user);
+    } else {
       router.push('/login');
     }
-  }, [authenticated, router])
-
-  useEffect(() => {
-    token && setAuthenticated(true);
-  }, [token])
-
-  useEffect(() => {
-    axios.get('http://localhost:3000/api/user/1')
-      .then(res => setUser(res.data))
-  }, [])
+  }, [router])
 
   return (
-    <AuthContext.Provider value={{authenticated, setToken, user}}>
+    <AuthContext.Provider value={{user, setUser}}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/hooks/useLogin.tsx
+++ b/src/hooks/useLogin.tsx
@@ -23,7 +23,14 @@ const useLogin = () => {
     }
   };
 
-  return login;
+  // TODO: Implements this methods
+  const logout = () => {
+    // 1. Remove token
+    // 2. Clean user object On AuthProvider
+    // 3. Redirect to '/login' page
+  }
+
+  return { login, logout };
 }
 
 export default useLogin;

--- a/src/hooks/useLogin.tsx
+++ b/src/hooks/useLogin.tsx
@@ -1,19 +1,22 @@
 import axios from 'axios';
+import jwt_decode from 'jwt-decode';
 import { useRouter } from 'next/router';
 import { useAuthProvider } from '../context/authContext';
 
 const useLogin = () => {
-  const { setToken } = useAuthProvider()
+  const { setUser } = useAuthProvider()
   const router = useRouter();
 
-  const login = async (event: React.FormEvent<HTMLFormElement>) => {
+  const login = async (event: React.FormEvent<HTMLFormElement>): Promise<void | string> => {
     event.preventDefault();
     const data = new FormData(event.currentTarget);
     try {
-      const response = await axios.post(
+      const { data: { token } } = await axios.post(
         `http://localhost:3000/api/login?email=${data.get('email')}&password=${data.get('password')}`
       );
-      setToken(response.data.token);
+      localStorage.setItem('token', token);
+      const user = jwt_decode(token);
+      setUser(user);
       router.push('/');
     } catch (err) {
       return err.response.data.error;

--- a/src/pages/api/login/index.ts
+++ b/src/pages/api/login/index.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { PrismaClient } from "@prisma/client";
+import jwt from "jwt-simple";
 
 const prisma = new PrismaClient();
 
@@ -13,16 +14,14 @@ const login = async (res: NextApiResponse, params: loginParams) => {
   const user = await prisma.user.findUnique({ where: { email } });
 
   if (!user || user.password !== password) {
-    return res
-      .status(400)
-      .json({
-        error: "Este e-mail não está cadastrado ou a senha está errada.",
-      });
+    return res.status(400).json({
+      error: "Este e-mail não está cadastrado ou a senha está errada.",
+    });
   }
 
-  // delete user.password;
-  // const token = jwt.encode(user, 'segredo');
-  res.status(200).json({ token: true });
+  delete user.password;
+  const token = jwt.encode(user, process.env.SECRET);
+  res.status(200).json({ token });
 };
 
 export default async function userHandler(

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,6 +3,8 @@ import { useAuthProvider } from "../context/authContext";
 function Home() {
   const { user } = useAuthProvider();
 
+   // TODO: solve the issue -> Use can see login page before redirect
+   // Actually, user can't see, but this way is not the best.
   if (!user) return;
 
   return (

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,9 @@
 import { useAuthProvider } from "../context/authContext";
 
-interface homeProps {}
-
-function Home(props: homeProps) {
+function Home() {
   const { user } = useAuthProvider();
+
+  if (!user) return;
 
   return (
     <ul>

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -14,20 +14,25 @@ import { useAuthProvider } from '../context/authContext';
 
 function Login() {
   const [loginSubmitError, setLoginSubmitError] = useState('');
-  const login = useLogin();
+
+  const { user } = useAuthProvider();
+  const { login } = useLogin();
   const router = useRouter();
-  const { autheticated } = useAuthProvider();
 
   useEffect(() => {
-    if (autheticated) {
+    if (user) {
       router.push('/')
     }
-  })
+  }, [user, router])
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    // TODO: Implements a loadder behavior when user is loggins
     const error = await login(e);
     error && setLoginSubmitError(error);
   }
+
+  // TODO: solve the issue -> Use can see login page before redirect
+  if (user) return;
 
   return (
     <Grid container component="main" sx={{ height: '100vh' }}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1585,6 +1585,16 @@ json5@^1.0.1:
     array-includes "^3.1.5"
     object.assign "^4.1.3"
 
+jwt-decode@^3.1.2:
+  version "3.1.2"
+  resolved "https://nexus.quintoandar.com.br/repository/npm-registry/jwt-decode/-/jwt-decode-3.1.2.tgz#3fb319f3675a2df0c2895c8f5e9fa4b67b04ed59"
+  integrity sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==
+
+jwt-simple@^0.5.6:
+  version "0.5.6"
+  resolved "https://nexus.quintoandar.com.br/repository/npm-registry/jwt-simple/-/jwt-simple-0.5.6.tgz#3357adec55b26547114157be66748995b75b333a"
+  integrity sha512-40aUybvhH9t2h71ncA1/1SbtTNCVZHgsTsTgqPUxGWDmUDrXyDf2wMNQKEbdBjbf4AI+fQhbECNTV6lWxQKUzg==
+
 language-subtag-registry@~0.3.2:
   version "0.3.22"
   resolved "https://nexus.quintoandar.com.br/repository/npm-registry/language-subtag-registry/-/language-subtag-registry-0.3.22.tgz#2e1500861b2e457eba7e7ae86877cbd08fa1fd1d"


### PR DESCRIPTION
# Description
This **PR** implements a real token response in _login route_.  The app now handles the _token_ to save it to local storage after the user logs in or to get it from local storage when the `'/'` page is accessed.

There are two redirect rules, in short:
1. when accessing `'/login'`, redirect to `'/'` if user is logged in;
2. when accessing `'/'`, redirect to `'/login'` if user is not logged in.

# Extra
- I created a variable called SECRET in .env to be used as a secret in the `jwt.encode()` method;
- Since the token has all the user info, I removed the _token state_ in `AuthProvider` because we can get the user info just decoding the token, while the token is useless after getting this information;
- I inserted some TODO comments in the code as a guide to the next steps.

# Libs
- `jwt-simple`: To be used on back-end, generating tokens;
- `jwt-decode` To be used on front-end, decoding tokens as I have a hard time using `jwt-simple` on front-end.